### PR TITLE
Enable Google Analytics in production only

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
-baseurl = "https://www.weshargrove.com/"
+baseURL = "https://www.weshargrove.com/"
 languageCode = "en-US"
 title = "Wes Hargrove Photography - Landscape Photography"
+GoogleAnalytics = "UA-41377193-1"
 
 contentDir = "content"
 layoutDir = "layouts"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,14 +1,18 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}" prefix="og: http://ogp.me/ns#">
 <head>
+  {{ if .Site.IsServer }}
+  <!-- Google analytics disabled for development -->
+  {{ else }}
   <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-41377193-1"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'UA-41377193-1');
+    gtag('config', {{ .Site.GoogleAnalytics }});
   </script>
+  {{ end }}
   {{ if .IsPage }}
   <title>{{ .Title}} | {{ .Site.Title }}</title>
   <meta property="og:title" content="{{ .Title }} | {{ .Site.Title }}" />


### PR DESCRIPTION
- If site is being served from `hugo serve` then do not include Google
  Analytics tracking code.
- Move Google Analytics tracking code to config.
- Fix editorconfig file so that it plays nicely with Makefile.